### PR TITLE
Fix const-correctness on operator overloads, stop returning references t...

### DIFF
--- a/Sparky-core/src/maths/mat4.cpp
+++ b/Sparky-core/src/maths/mat4.cpp
@@ -31,20 +31,21 @@ namespace sparky { namespace maths {
         elements[3 + 3 * 4] = diagonal;
     }
 
-    mat4::mat4(float *elements)
+    mat4::mat4(const float *elements)
     {
         for (int i = 0; i < 4 * 4; i++)
             this->elements[i] = elements[i];
     }
-
-    mat4& mat4::translate(vec3& vector)
+    
+    mat4 mat4::translate(const vec3& vector) const
     {
-        mat4 result(1.0f);
-        elements[0 + 3 * 4] = vector.x;
-        elements[1 + 3 * 4] = vector.y;
-        elements[2 + 3 * 4] = vector.z;
-        return *this * result;
+        mat4 translation(1.0f);
+        translation.elements[0 + 3 * 4] = vector.x;
+        translation.elements[1 + 3 * 4] = vector.y;
+        translation.elements[2 + 3 * 4] = vector.z;
+        return *this * translation;
     }
+
 
     mat4 mat4::identity()
     {
@@ -75,11 +76,14 @@ namespace sparky { namespace maths {
 
     mat4& mat4::operator*=(const mat4 &right)
     {
-        return *this * right;
+        *this = *this * right;
+        return *this;
     }
 
-    mat4 operator*(mat4 left, const mat4 &right)
+    mat4 operator*(const mat4 &left, const mat4 &right)
     {
+        mat4 result;
+
         for (int y = 0; y < 4; y++)
         {
             for (int x = 0; x < 4; x++)
@@ -89,10 +93,11 @@ namespace sparky { namespace maths {
                 {
                     sum += left.elements[x + i * 4] * right.elements[i + y * 4];
                 }
-                left.elements[x + y * 4] = sum;
+                result.elements[y + x * 4] = sum;
             }
         }
-        return left;
+
+        return result;
     }
 
 } }

--- a/Sparky-core/src/maths/mat4.h
+++ b/Sparky-core/src/maths/mat4.h
@@ -15,9 +15,10 @@ namespace sparky { namespace maths {
     public:
         mat4();
         mat4(float diagonal);
-        mat4(float *elements);
+        mat4(const float *elements);
+		
+        mat4 translate(const vec3& vector) const;
 
-        mat4& translate(vec3& vector);
 
         inline const float* to_array() const
         {
@@ -25,7 +26,8 @@ namespace sparky { namespace maths {
         }
 
         mat4& operator*=(const mat4 &right);
-        friend mat4 operator*(mat4 left, const mat4 &right);
+        friend mat4 operator*(const mat4 &left, const mat4 &right);
+
     public:
         static mat4 identity();
         static mat4 orthographic(float left, float right, float bottom, float top, float near, float far);

--- a/Sparky-core/src/maths/vec3.cpp
+++ b/Sparky-core/src/maths/vec3.cpp
@@ -25,19 +25,16 @@ namespace sparky { namespace maths {
 
     vec3& vec3::add(const vec3 &other)
     {
-        x += other.x;
-        y += other.y;
-        z += other.z;
+        *this = *this + other;
         return *this;
     }
 
     vec3& vec3::subtract(const vec3 &other)
     {
-        x -= other.x;
-        y -= other.y;
-        z -= other.z;
+        *this = *this - other;
         return *this;
     }
+
     vec3& vec3::operator += (const vec3 &other)
     {
         return add(other);
@@ -47,15 +44,15 @@ namespace sparky { namespace maths {
     {
         return subtract(other);
     }
-
-    vec3& operator+(vec3 left, const vec3 &right)
+    
+    vec3 operator+(const vec3 &left, const vec3 &right)
     {
-        return left += right;
+        return vec3(left.x + right.x, left.y + right.y, left.z + right.z);
     }
 
-    vec3& operator-(vec3 left, const vec3 &right)
+    vec3 operator-(const vec3 &left, const vec3 &right)
     {
-        return left -= right;
+        return vec3(left.x - right.x, left.y - right.y, left.z - right.z);
     }
 
     std::ostream& operator<<(std::ostream &stream, const vec3 &vector)

--- a/Sparky-core/src/maths/vec3.h
+++ b/Sparky-core/src/maths/vec3.h
@@ -20,19 +20,21 @@ namespace sparky { namespace maths {
         vec3& operator+=(const vec3 &other);
         vec3& operator-=(const vec3 &other);
 
-        friend vec3& operator+(vec3 left, const vec3 &right);
-        friend vec3& operator-(vec3 left, const vec3 &right);
-
         inline bool operator==(const vec3 &other) const
         {
             return x == other.x && y == other.y && z == other.z;
         }
+
         inline bool operator!=(const vec3 &other) const
         {
             return !(*this == other);
         }
 
-        friend std::ostream& operator<<(std::ostream &stream, const vec3 &vector);
     };
+
+    vec3 operator+(const vec3 &left, const vec3 &right);
+    vec3 operator-(const vec3 &left, const vec3 &right);
+    std::ostream& operator<<(std::ostream &stream, const vec3 &vector);
+
 
 } }


### PR DESCRIPTION
Sorry, I really should have split this into two separate PRs. I did a bunch of const-correctness fixes, especially around operator overloading, and made sure that you weren't returning references to local variables in any of the operator calls.

At the same time, I believe I found a bug in mat4::translate(). You were merging the translation vector into elements, when I believe you intended to merge it into the "result" variable, before multiplying. I think I've fixed this
